### PR TITLE
Make icon copy and clone

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -45,7 +45,7 @@ pub struct Cli {
     pub repository_url: Option<String>,
 
     /// Path to the README of the output library
-    #[arg(long, short, default_value_t = String::from("README.md"))]
+    #[arg(long, short = 'p', default_value_t = String::from("README.md"))]
     pub readme_path: String,
 
     /// Authors of the output library

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -175,7 +175,7 @@ pub fn generate_icons_enum(icons: &BTreeMap<String, IconInfo>) -> anyhow::Result
         .collect::<Vec<_>>();
 
     let output = quote! {
-        #[derive(Debug)]
+        #[derive(Debug, Clone, Copy)]
         pub enum Icon {
             #(#variants),*
         }


### PR DESCRIPTION
The `Icon` enum is now `Copy` and `Clone`

closes #2 